### PR TITLE
Fix for crash when NYT returns an article with no images

### DIFF
--- a/app/src/main/java/com/example/nyt/ArticleAdapter.java
+++ b/app/src/main/java/com/example/nyt/ArticleAdapter.java
@@ -76,9 +76,15 @@ public class ArticleAdapter extends RecyclerView.Adapter<ArticleAdapter.ArticleV
         });
 
 //        holder.articleImageView.setImageResource(articleAtPosition.getImageDrawableId());
-        if (articleAtPosition.getMedia() != null) {
-            String imageUrl = articleAtPosition.getMedia()[0].getMedia_metadata()[0].getUrl();
-            Glide.with(holder.view.getContext()).load(imageUrl).into(holder.articleImageView);
+        try {
+            //i wrapped this in a try catch bcos the null check wasnt working
+            if (articleAtPosition.getMedia() != null) {
+                String imageUrl = articleAtPosition.getMedia()[0].getMedia_metadata()[0].getUrl();
+                Glide.with(holder.view.getContext()).load(imageUrl).into(holder.articleImageView);
+            }
+        }catch (ArrayIndexOutOfBoundsException e){
+            //if you cant find an image, use this image of a cloud with a line through it instead
+            holder.articleImageView.setImageResource(R.drawable.ic_cloud_off_black_24dp);
         }
     }
 

--- a/app/src/main/java/com/example/nyt/fragments/ArticleRecyclerFragment.java
+++ b/app/src/main/java/com/example/nyt/fragments/ArticleRecyclerFragment.java
@@ -1,6 +1,7 @@
 package com.example.nyt.fragments;
 
 import android.os.Bundle;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -52,6 +53,9 @@ public class ArticleRecyclerFragment extends Fragment {
         Response.Listener<String> responseListener = new Response.Listener<String>() {
             @Override
             public void onResponse(String response) {
+                //this is because NYT when it doesn't have any media returns "" instead of []
+                //this makes gson unhappy because it expects am array and gets a string instead
+                response = response.replace("media\":\"\"", "media\":[]");
                 Gson gson = new Gson();
                 TopStoriesResponse topStoriesResponse = gson.fromJson(response, TopStoriesResponse.class);
                 articleAdapter.setData(topStoriesResponse.results);

--- a/app/src/main/res/drawable/ic_cloud_off_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_cloud_off_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M19.35,10.04C18.67,6.59 15.64,4 12,4c-1.48,0 -2.85,0.43 -4.01,1.17l1.46,1.46C10.21,6.23 11.08,6 12,6c3.04,0 5.5,2.46 5.5,5.5v0.5H19c1.66,0 3,1.34 3,3 0,1.13 -0.64,2.11 -1.56,2.62l1.45,1.45C23.16,18.16 24,16.68 24,15c0,-2.64 -2.05,-4.78 -4.65,-4.96zM3,5.27l2.75,2.74C2.56,8.15 0,10.77 0,14c0,3.31 2.69,6 6,6h11.73l2,2L21,20.73 4.27,4 3,5.27zM7.73,10l8,8H6c-2.21,0 -4,-1.79 -4,-4s1.79,-4 4,-4h1.73z"/>
+</vector>


### PR DESCRIPTION
When the NYT api returns an article with no images, it returns `"media": "",` instead of `"media":[],` This makes gson think it's a string when it's expecting an array, causing the app to crash.

I added a line that replaces the incorrect json with the correct one in ArticleRecyclerFragment. 

For some reason the check for a null array wasn't working in ArticleAdapter, so I wrapped it in a try catch block and just set the imageview to a placeholder image.